### PR TITLE
add regex option to match test cases

### DIFF
--- a/test.rb
+++ b/test.rb
@@ -52,6 +52,10 @@ OptionParser.new do |opts|
   opts.on("-p", "--prompt", "Whether to prompt to save tests") do |p|
     options[:prompt] = p
   end
+
+    opts.on("-r" "--regex", "Pattern to match tests to run") do |r|
+    options[:regex] = r || ""
+  end
 end.parse!
 
 if options[:compiler].nil? || !File.exist?(options[:compiler])
@@ -82,7 +86,7 @@ end
 
 count = 0
 
-files = Dir["#{options[:dir]}/*.c"].sort
+files = Dir["#{options[:dir]}/*#{options[:regex]}*.c"].sort
 count = files.size
 
 encouraging_messages = [

--- a/test.rb
+++ b/test.rb
@@ -86,7 +86,9 @@ end
 
 count = 0
 
-files = Dir["#{options[:dir]}/*#{options[:regex]}*.c"].sort
+files = Dir["#{options[:dir]}/*.c"].sort
+files = files.select { |f| f =~ /#{options[:regex]}/ } if options[:regex]
+
 count = files.size
 
 encouraging_messages = [


### PR DESCRIPTION
I don't know ruby well so there is probably a better way to write this, but it is useful to me.
It just adds a -r option to pass a regex to match tests to run.